### PR TITLE
Fixed a bug with the ConsoleLogger class

### DIFF
--- a/inc/logger.h
+++ b/inc/logger.h
@@ -32,9 +32,9 @@ class ConsoleLogger : public Logger {
     Q_OBJECT
 
 protected:
-    void writeInfo(QString msg);
-    void writeWarning(QString msg);
-    void writeError(QString msg);
+    virtual void writeInfo(QString msg) override;
+    virtual void writeWarning(QString msg) override;
+    virtual void writeError(QString msg) override;
 };
 
 class FileLogger : public Logger {
@@ -45,9 +45,9 @@ public:
     explicit FileLogger(QString fileName);
 
 protected:
-    void writeInfo(QString msg);
-    void writeWarning(QString msg);
-    void writeError(QString msg);
+    virtual void writeInfo(QString msg) override;
+    virtual void writeWarning(QString msg) override;
+    virtual void writeError(QString msg) override;
 };
 
 #endif // LOGGER_H

--- a/inc/logger.h
+++ b/inc/logger.h
@@ -31,9 +31,6 @@ public slots:
 class ConsoleLogger : public Logger {
     Q_OBJECT
 
-public:
-    ConsoleLogger();
-
 protected:
     void writeInfo(QString msg);
     void writeWarning(QString msg);


### PR DESCRIPTION
Removed the default constructor from the header file. This was causing a linking issue when create instances of ConsoleLogger.